### PR TITLE
Fix errors picked up by Travis

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,103 +16,120 @@
 class snmp::params {
   # If we have a top scope variable defined, use it, otherwise fall back to a
   # hardcoded value.
-  if getvar('::snmp_agentaddress') {
+  $snmp_agentaddress = getvar('::snmp_agentaddress')
+  if $snmp_agentaddress {
     $agentaddress = $::snmp_agentaddress
   } else {
     $agentaddress = [ 'udp:127.0.0.1:161', 'udp6:[::1]:161' ]
   }
 
-  if getvar('::snmp_master') {
+  $snmp_master = getvar('::snmp_master')
+  if $snmp_master {
     $master = $::snmp_master
   } else {
     $master = 'agentx'
   }
 
-  if getvar('::snmp_snmptrapdaddr') {
+  $snmp_snmptrapdaddr = getvar('::snmp_snmptrapdaddr')
+  if $snmp_snmptrapdaddr {
     $snmptrapdaddr = $::snmp_snmptrapdaddr
   } else {
     $snmptrapdaddr =  [ 'udp:127.0.0.1:162', 'udp6:[::1]:162' ]
   }
 
-  if getvar('::snmp_ro_community') {
+  $snmp_ro_community = getvar('::snmp_ro_community')
+  if $snmp_ro_community {
     $ro_community = $::snmp_ro_community
   } else {
     $ro_community =  'public'
   }
 
-  if getvar('::snmp_ro_community6') {
+  $snmp_ro_community6 = getvar('::snmp_ro_community6')
+  if $snmp_ro_community6 {
     $ro_community6 = $::snmp_ro_community6
   } else {
     $ro_community6 =  'public'
   }
 
-  if getvar('::snmp_rw_community') {
+  $snmp_rw_community = getvar('::snmp_rw_community')
+  if $snmp_rw_community {
     $rw_community = $::snmp_rw_community
   } else {
     $rw_community =  undef
   }
 
-  if getvar('::snmp_rw_community6') {
+  $snmp_rw_community6 = getvar('::snmp_rw_community6')
+  if $snmp_rw_community6 {
     $rw_community6 =  $::snmp_rw_community6
   } else {
     $rw_community6 =  undef
   }
 
-  if getvar('::snmp_ro_network') {
+  $snmp_ro_network = getvar('::snmp_ro_network')
+  if $snmp_ro_network {
     $ro_network =  $::snmp_ro_network
   } else {
     $ro_network =  '127.0.0.1'
   }
 
-  if getvar('::snmp_ro_network6') {
+  $snmp_ro_network6 = getvar('::snmp_ro_network6')
+  if $snmp_ro_network6 {
     $ro_network6 =  $::snmp_ro_network6
   } else {
     $ro_network6 =  '::1'
   }
 
-  if getvar('::snmp_rw_network') {
+  $snmp_rw_network = getvar('::snmp_rw_network')
+  if $snmp_rw_network {
     $rw_network =  $::snmp_rw_network
   } else {
     $rw_network =  '127.0.0.1'
   }
 
-  if getvar('::snmp_rw_network6') {
+  $snmp_rw_network6 = getvar('::snmp_rw_network6')
+  if $snmp_rw_network6 {
     $rw_network6 =  $::snmp_rw_network6
   } else {
     $rw_network6 =  '::1'
   }
 
-  if getvar('::snmp_contact') {
+  $snmp_contact = getvar('::snmp_contact')
+  if $snmp_contact {
     $contact =  $::snmp_contact
   } else {
     $contact =  'Unknown'
   }
 
-  if getvar('::snmp_location') {
+  $snmp_location = getvar('::snmp_location')
+  if $snmp_location {
     $location =  $::snmp_location
   } else {
     $location =  'Unknown'
   }
 
-  if getvar('::snmp_sysname') {
+  $snmp_sysname = getvar('::snmp_sysname')
+  if $snmp_sysname {
     $sysname =  $::snmp_sysname
   } else {
     $sysname =  $::fqdn
   }
 
-  if getvar('::snmp_com2sec') {
+  $snmp_com2sec = getvar('::snmp_com2sec')
+  if $snmp_com2sec {
     $com2sec =  $::snmp_com2sec
   } else {
     $com2sec =  [ 'notConfigUser  default       public', ]
   }
 
-  if getvar('::snmp_com2sec6') {
+  $snmp_com2sec6 = getvar('::snmp_com2sec6')
+  if $snmp_com2sec6 {
     $com2sec6 =  $::snmp_com2sec6
   } else {
     $com2sec6 =  [ 'notConfigUser  default       public', ]
   }
 
-  if getvar('::snmp_groups') {
+  $snmp_groups = getvar('::snmp_groups')
+  if $snmp_groups {
     $groups =  $::snmp_groups
   } else {
     $groups =  [
@@ -121,19 +138,22 @@ class snmp::params {
     ]
   }
 
-  if getvar('::snmp_services') {
+  $snmp_services = getvar('::snmp_services')
+  if $snmp_services {
     $services =  $::snmp_services
   } else {
     $services =  72
   }
 
-  if getvar('::openmanage_enable') {
-    $openmanage_enable =  $::openmanage_enable
+  $snmp_openmanage_enable = getvar('::openmanage_enable')
+  if $snmp_openmanage_enable {
+    $openmanage_enable =  $snmp_openmanage_enable
   } else {
     $openmanage_enable =  false
   }
 
-  if getvar('::snmp_views') {
+  $snmp_views = getvar('::snmp_views')
+  if $snmp_views {
     $views =  $::snmp_views
   } else {
     $views =  [
@@ -142,7 +162,8 @@ class snmp::params {
     ]
   }
 
-  if getvar('::snmp_accesses') {
+  $snmp_accesses = getvar('::snmp_accesses')
+  if $snmp_accesses {
     $accesses =  $::snmp_accesses
   } else {
     $accesses =  [
@@ -150,55 +171,64 @@ class snmp::params {
     ]
   }
 
-  if getvar('::snmp_dlmod') {
+  $snmp_dlmod = getvar('::snmp_dlmod')
+  if $snmp_dlmod {
     $dlmod =  $::snmp_dlmod
   } else {
     $dlmod =  []
   }
 
-  if getvar('::snmp_disable_authorization') {
+  $snmp_disable_authorization = getvar('::snmp_disable_authorization')
+  if $snmp_disable_authorization {
     $disable_authorization =  $::snmp_disable_authorization
   } else {
     $disable_authorization =  'no'
   }
 
-  if getvar('::snmp_do_not_log_traps') {
+  $snmp_do_not_log_traps = getvar('::snmp_do_not_log_traps')
+  if $snmp_do_not_log_traps {
     $do_not_log_traps =  $::snmp_do_not_log_traps
   } else {
     $do_not_log_traps =  'no'
   }
 
-  if getvar('::snmp_do_not_log_tcpwrappers') {
+  $snmp_do_not_log_tcpwrappers = getvar('::snmp_do_not_log_tcpwrappers')
+  if $snmp_do_not_log_tcpwrappers {
     $do_not_log_tcpwrappers =  $::snmp_do_not_log_tcpwrappers
   } else {
     $do_not_log_tcpwrappers =  'no'
   }
 
-  if getvar('::snmp_trap_handlers') {
+  $snmp_trap_handlers = getvar('::snmp_trap_handlers')
+  if $snmp_trap_handlers {
     $trap_handlers =  $::snmp_trap_handlers
   } else {
     $trap_handlers =  []
   }
 
-  if getvar('::snmp_trap_forwards') {
+  $snmp_trap_forwards = getvar('::snmp_trap_forwards')
+  if $snmp_trap_forwards {
     $trap_forwards =  $::snmp_trap_forwards
   } else {
     $trap_forwards =  []
   }
 
-  if getvar('::snmp_snmp_config') {
+  $snmp_snmp_config = getvar('::snmp_snmp_config')
+  if $snmp_snmp_config {
     $snmp_config =  $::snmp_snmp_config
   } else {
     $snmp_config =  []
   }
 
-  if getvar('::snmp_snmpd_config') {
+  $snmp_snmpd_config = getvar('::snmp_snmpd_config')
+  if $snmp_snmpd_config {
     $snmpd_config =  $::snmp_snmpd_config
   } else {
     $snmpd_config =  []
   }
 
-  if getvar('::snmp_snmptrapd_config') {
+  $snmp_snmptrapd_config = getvar('::snmp_snmptrapd_config')
+  if $snmp_snmptrapd_config {
     $snmptrapd_config =  $::snmp_snmptrapd_config
   } else {
     $snmptrapd_config =  []
@@ -206,19 +236,22 @@ class snmp::params {
 
 ### The following parameters should not need to be changed.
 
-  if getvar('::snmp_ensure') {
+  $snmp_ensure = getvar('::snmp_ensure')
+  if $snmp_ensure {
     $ensure =  $::snmp_ensure
   } else {
     $ensure =  'present'
   }
 
-  if getvar('::snmp_service_ensure') {
+  $snmp_service_ensure = getvar('::snmp_service_ensure')
+  if $snmp_service_ensure {
     $service_ensure =  $::snmp_service_ensure
   } else {
     $service_ensure =  'running'
   }
 
-  if getvar('::snmp_trap_service_ensure') {
+  $snmp_trap_service_ensure = getvar('::snmp_trap_service_ensure')
+  if $snmp_trap_service_ensure {
     $trap_service_ensure =  $::snmp_trap_service_ensure
   } else {
     $trap_service_ensure =  'stopped'
@@ -226,7 +259,8 @@ class snmp::params {
 
   # Since the top scope variable could be a string (if from an ENC), we might
   # need to convert it to a boolean.
-  if getvar('::snmp_autoupgrade') {
+  $snmp_autoupgrade = getvar('::snmp_autoupgrade')
+  if $snmp_autoupgrade {
     $autoupgrade =  $::snmp_autoupgrade
   } else {
     $autoupgrade =  false
@@ -237,13 +271,15 @@ class snmp::params {
     $safe_autoupgrade = $autoupgrade
   }
 
-  if getvar('::snmp_install_client') {
+  $snmp_install_client = getvar('::snmp_install_client')
+  if $snmp_install_client {
     $install_client =  $::snmp_install_client
   } else {
     $install_client =  undef
   }
 
-  if getvar('::snmp_manage_client') {
+  $snmp_manage_client = getvar('::snmp_manage_client')
+  if $snmp_manage_client {
     $manage_client =  $::snmp_manage_client
   } else {
     $manage_client =  false
@@ -254,7 +290,8 @@ class snmp::params {
     $safe_manage_client = $manage_client
   }
 
-  if getvar('::snmp_service_enable') {
+  $snmp_service_enable = getvar('::snmp_service_enable')
+  if $snmp_service_enable {
     $service_enable =  $::snmp_service_enable
   } else {
     $service_enable =  true
@@ -265,7 +302,8 @@ class snmp::params {
     $safe_service_enable = $service_enable
   }
 
-  if getvar('::snmp_service_hasstatus') {
+  $snmp_service_hasstatus = getvar('::snmp_service_hasstatus')
+  if $snmp_service_hasstatus {
     $service_hasstatus =  $::snmp_service_hasstatus
   } else {
     $service_hasstatus =  true
@@ -276,7 +314,8 @@ class snmp::params {
     $safe_service_hasstatus = $service_hasstatus
   }
 
-  if getvar('::snmp_service_hasrestart') {
+  $snmp_service_hasrestart = getvar('::snmp_service_hasrestart')
+  if $snmp_service_hasrestart {
     $service_hasrestart =  $::snmp_service_hasrestart
   } else {
     $service_hasrestart =  true
@@ -287,7 +326,8 @@ class snmp::params {
     $safe_service_hasrestart = $service_hasrestart
   }
 
-  if getvar('::snmp_trap_service_enable') {
+  $snmp_trap_service_enable = getvar('::snmp_trap_service_enable')
+  if $snmp_trap_service_enable {
     $trap_service_enable =  $::snmp_trap_service_enable
   } else {
     $trap_service_enable =  false
@@ -298,7 +338,8 @@ class snmp::params {
     $safe_trap_service_enable = $trap_service_enable
   }
 
-  if getvar('::snmp_trap_service_hasstatus') {
+  $snmp_trap_service_hasstatus = getvar('::snmp_trap_service_hasstatus')
+  if $snmp_trap_service_hasstatus {
     $trap_service_hasstatus =  $::snmp_trap_service_hasstatus
   } else {
     $trap_service_hasstatus =  true
@@ -309,7 +350,8 @@ class snmp::params {
     $safe_trap_service_hasstatus = $trap_service_hasstatus
   }
 
-  if getvar('::snmp_trap_service_hasrestart') {
+  $snmp_trap_service_hasrestart = getvar('::snmp_trap_service_hasrestart')
+  if $snmp_trap_service_hasrestart {
     $trap_service_hasrestart =  $::snmp_trap_service_hasrestart
   } else {
     $trap_service_hasrestart =  true
@@ -325,13 +367,15 @@ class snmp::params {
   $template_snmptrapd = 'snmp/snmptrapd.conf.erb'
   $template_snmptrapd_sysconfig = "snmp/snmptrapd.sysconfig-${::osfamily}.erb"
 
-  if getvar('::snmp_proxy') {
+  $snmp_proxy = getvar('::snmp_proxy')
+  if $snmp_proxy {
     $proxy = $::snmp_proxy
   } else {
     $proxy   = []
   }
 
-  if getvar('::snmp_rw_users') {
+  $snmp_rw_users = getvar('::snmp_rw_users')
+  if $snmp_rw_users {
     $rwusers = $::snmp_rw_users
   } else {
     $rwusers = []
@@ -339,9 +383,11 @@ class snmp::params {
 
   case $::osfamily {
     'RedHat': {
-      if getvar('::operatingsystemmajrelease') { # facter 1.7+
+      $osmr = getvar('::operatingsystemmajrelease')
+      $lsbmdr = getvar('::lsbmajdistrelease')
+      if $osmr {
         $majdistrelease = $::operatingsystemmajrelease
-      } elsif getvar('::lsbmajdistrelease') {    # requires LSB to already be installed
+      } elsif $lsbmdr {    # requires LSB to already be installed
         $majdistrelease = $::lsbmajdistrelease
       } else {
         $majdistrelease = regsubst($::operatingsystemrelease,'^(\d+)\.(\d+)','\1')
@@ -357,7 +403,7 @@ class snmp::params {
           $service_config_perms = '0600'
         }
         default: {
-          if $majdistrelease <= '5' {
+          if versioncmp($majdistrelease, '5') <= 0 {
             $snmpd_options        = '-Lsd -Lf /dev/null -p /var/run/snmpd.pid -a'
             $sysconfig            = '/etc/sysconfig/snmpd.options'
             $trap_sysconfig       = '/etc/sysconfig/snmptrapd.options'

--- a/templates/snmp.conf.erb
+++ b/templates/snmp.conf.erb
@@ -1,6 +1,8 @@
 ###
 ### File managed by Puppet
 ###
+<% if (@snmp_config.is_a?(Array)) and (@snmp_config.count > 0) -%>
 <% @snmp_config.each do |line| -%>
 <%= line %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
* Fixes the `getvar` Travis errors in https://github.com/razorsedge/puppet-snmp/pull/97 
* Adds a check for an unset variable in one of the templates
* Fixes version check with `versioncmp`